### PR TITLE
Upgrades to vulkan arm build

### DIFF
--- a/.github/workflows/vulkan-arm.yml
+++ b/.github/workflows/vulkan-arm.yml
@@ -107,11 +107,11 @@ jobs:
           DATE=$(date -u +'%Y%m%d%H%M')
           VERSION="${{ github.event.inputs.version || env.DEFAULT_VULKAN_SDK_VERSION }}"
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "tag=${VERSION}-${DATE}" >> $GITHUB_OUTPUT
+            echo "tag=vulkan-sdk-${VERSION}-${DATE}" >> $GITHUB_OUTPUT
           else
             PR_BRANCH="${{ github.head_ref }}"
             PR_BRANCH_CLEAN=$(echo "$PR_BRANCH" | tr '/' '-' | tr -cd '[:alnum:]-')
-            echo "tag=${VERSION}-${PR_BRANCH_CLEAN}-${DATE}" >> $GITHUB_OUTPUT
+            echo "tag=vulkan-sdk-${VERSION}-${PR_BRANCH_CLEAN}-${DATE}" >> $GITHUB_OUTPUT
           fi
 
       - name: Set prerelease flag
@@ -130,7 +130,6 @@ jobs:
           prerelease: ${{ steps.set_prerelease.outputs.is_prerelease }}
           name: ${{ steps.set_tag.outputs.tag }}
           body: |
-            Blah blah
-            Tag: ${{ steps.set_tag.outputs.tag }}
+            Vulkan SDK build for GsTaichi.
           files: |
             dist/**


### PR DESCRIPTION
Upgrades to vulkan arm build
- upgrade default version to 1.4.321.1
- move default version to single place
- generalize tar -xJf to support other file types
- automatically create release with the built files
    - release sets 'pre-release' to true when not building off main
    - name contains date/time so unique name
    - when building from pr, includes name of branch in release name