### PR TITLE
Speed up LLVM SDK builds, especially Windows

### DIFF
--- a/.github/workflows/llvm-ci.yml
+++ b/.github/workflows/llvm-ci.yml
@@ -130,6 +130,8 @@ jobs:
           git checkout --detach FETCH_HEAD
 
           cmake -S llvm -B build -G Ninja `
+            -DCMAKE_C_COMPILER=cl `
+            -DCMAKE_CXX_COMPILER=cl `
             -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_INSTALL_PREFIX="$env:CMAKE_INSTALL_PREFIX" `
             -DLLVM_ENABLE_PROJECTS="clang" `

--- a/.github/workflows/llvm-ci.yml
+++ b/.github/workflows/llvm-ci.yml
@@ -115,12 +115,18 @@ jobs:
           $ErrorActionPreference = 'Stop'
           Write-Host "Using LLVM_TAG=$env:LLVM_TAG"
 
-          $vsPath = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat"
-          cmd /c "`"$vsPath`" && set" | ForEach-Object {
+          # Use vcvarsall to set up MSVC x64 environment
+          $vcvarsall = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
+          cmd /c "`"$vcvarsall`" x64 && set" | ForEach-Object {
               if ($_ -match '^([^=]+)=(.*)') {
                   [Environment]::SetEnvironmentVariable($matches[1], $matches[2])
               }
           }
+
+          # Remove MSYS2/MinGW from PATH so CMake Ninja finds MSVC cl.exe
+          $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -notmatch 'msys|mingw' }) -join ';'
+
+          Write-Host "CC = $(where.exe cl 2>&1 | Select-Object -First 1)"
 
           New-Item -ItemType Directory -Force -Path llvm-project | Out-Null
           Set-Location llvm-project

--- a/.github/workflows/llvm-ci.yml
+++ b/.github/workflows/llvm-ci.yml
@@ -115,8 +115,11 @@ jobs:
           $ErrorActionPreference = 'Stop'
           Write-Host "Using LLVM_TAG=$env:LLVM_TAG"
 
-          # Use vcvarsall to set up MSVC x64 environment
-          $vcvarsall = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
+          # Find VS installation and set up MSVC x64 environment
+          $vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstall = & $vsWhere -latest -property installationPath
+          Write-Host "VS install path: $vsInstall"
+          $vcvarsall = Join-Path $vsInstall "VC\Auxiliary\Build\vcvarsall.bat"
           cmd /c "`"$vcvarsall`" x64 && set" | ForEach-Object {
               if ($_ -match '^([^=]+)=(.*)') {
                   [Environment]::SetEnvironmentVariable($matches[1], $matches[2])
@@ -126,7 +129,8 @@ jobs:
           # Remove MSYS2/MinGW from PATH so CMake Ninja finds MSVC cl.exe
           $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -notmatch 'msys|mingw' }) -join ';'
 
-          Write-Host "CC = $(where.exe cl 2>&1 | Select-Object -First 1)"
+          $clPath = where.exe cl 2>&1 | Select-Object -First 1
+          Write-Host "cl.exe at: $clPath"
 
           New-Item -ItemType Directory -Force -Path llvm-project | Out-Null
           Set-Location llvm-project

--- a/.github/workflows/llvm-ci.yml
+++ b/.github/workflows/llvm-ci.yml
@@ -87,13 +87,20 @@ jobs:
           cmake -S llvm -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}" \
-            -DLLVM_ENABLE_PROJECTS="clang;lld" \
+            -DLLVM_ENABLE_PROJECTS="clang" \
             -DLLVM_ENABLE_RTTI:BOOL=ON \
             -DLLVM_ENABLE_LIBXML2=OFF \
             -DLLVM_ENABLE_ZLIB=OFF \
             -DLLVM_ENABLE_ZSTD=OFF \
             -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
-            -DLLVM_ENABLE_TERMINFO=OFF
+            -DLLVM_ENABLE_TERMINFO=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
+            -DLLVM_INCLUDE_DOCS=OFF \
+            -DCLANG_INCLUDE_TESTS=OFF \
+            -DCLANG_ENABLE_STATIC_ANALYZER=OFF \
+            -DCLANG_ENABLE_ARCMT=OFF
 
           cmake --build build --target all -- -k 0
           cmake --build build --target install
@@ -122,20 +129,28 @@ jobs:
           git fetch --depth 1 origin "$env:LLVM_TAG"
           git checkout --detach FETCH_HEAD
 
-          cmake -S llvm -B build -G "Visual Studio 17 2022" -A x64 `
+          cmake -S llvm -B build -G Ninja `
             -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_INSTALL_PREFIX="$env:CMAKE_INSTALL_PREFIX" `
-            -DLLVM_ENABLE_PROJECTS="clang;lld" `
+            -DLLVM_ENABLE_PROJECTS="clang" `
             -DLLVM_ENABLE_RTTI:BOOL=ON `
             -DLLVM_ENABLE_LIBXML2=OFF `
             -DLLVM_ENABLE_ZLIB=OFF `
             -DLLVM_ENABLE_ZSTD=OFF `
             -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" `
             -DLLVM_ENABLE_TERMINFO=OFF `
-            -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDLL"
+            -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDLL" `
+            -DLLVM_INCLUDE_TESTS=OFF `
+            -DLLVM_INCLUDE_EXAMPLES=OFF `
+            -DLLVM_INCLUDE_BENCHMARKS=OFF `
+            -DLLVM_INCLUDE_DOCS=OFF `
+            -DCLANG_INCLUDE_TESTS=OFF `
+            -DCLANG_ENABLE_STATIC_ANALYZER=OFF `
+            -DCLANG_ENABLE_ARCMT=OFF `
+            -DLLVM_PARALLEL_LINK_JOBS=2
 
-          cmake --build build --config Release --target ALL_BUILD
-          cmake --build build --config Release --target INSTALL
+          cmake --build build --target all -- -k 0
+          cmake --build build --target install
 
       # ----------  compute package naming ----------
       - name: Compute package name

--- a/.github/workflows/llvm-ci.yml
+++ b/.github/workflows/llvm-ci.yml
@@ -1,7 +1,7 @@
 name: Build LLVM (matrix)
 
 env:
-  DEFAULT_LLVM_VERSION: '15.0.7'
+  DEFAULT_LLVM_VERSION: '22.1.0'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/llvm-ci.yml
+++ b/.github/workflows/llvm-ci.yml
@@ -84,6 +84,11 @@ jobs:
           git fetch --depth 1 origin "${LLVM_TAG}"
           git checkout --detach FETCH_HEAD
 
+          extra_cmake_args=""
+          if [ "$(uname)" = "Darwin" ]; then
+            extra_cmake_args="-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0"
+          fi
+
           cmake -S llvm -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}" \
@@ -100,7 +105,8 @@ jobs:
             -DLLVM_INCLUDE_DOCS=OFF \
             -DCLANG_INCLUDE_TESTS=OFF \
             -DCLANG_ENABLE_STATIC_ANALYZER=OFF \
-            -DCLANG_ENABLE_ARCMT=OFF
+            -DCLANG_ENABLE_ARCMT=OFF \
+            $extra_cmake_args
 
           cmake --build build --target all -- -k 0
           cmake --build build --target install


### PR DESCRIPTION
Windows:
- Switch Windows from VS generator (MSBuild) to Ninja for ~30-50% faster builds
- Drop lld from LLVM_ENABLE_PROJECTS (quadrants does not use it)
- Disable tests, examples, benchmarks, docs builds
- Disable clang static analyzer and ARCMT (quadrants only needs the compiler)
- Limit parallel link jobs to 2 on Windows to prevent memory thrashing

Mac:
- change to os x 11, so built sdk compatibel with os x 11